### PR TITLE
Fix failing tests after enabling security root profile

### DIFF
--- a/src/platform/test/functional/apps/discover/group4/_adhoc_data_views.ts
+++ b/src/platform/test/functional/apps/discover/group4/_adhoc_data_views.ts
@@ -186,7 +186,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await addSearchToDashboard('logst*-ss-_bytes-runtimefield');
       await addSearchToDashboard('logst*-ss-_bytes-runtimefield-updated');
 
-      const [firstSearchCell, secondSearchCell] = await dataGrid.getAllCellElements(0, 3);
+      const [firstSearchCell, secondSearchCell] = await dataGrid.getAllCellElementsByColumnName(
+        0,
+        '_bytes-runtimefield'
+      );
       const first = await firstSearchCell.getVisibleText();
       const second = await secondSearchCell.getVisibleText();
 

--- a/src/platform/test/functional/services/data_grid.ts
+++ b/src/platform/test/functional/services/data_grid.ts
@@ -174,9 +174,13 @@ export class DataGridService extends FtrService {
     );
   }
 
+  private getCellElementByColumnNameSelector(rowIndex: number, columnName: string) {
+    return `[data-test-subj="euiDataGridBody"] [data-test-subj="dataGridRowCell"][data-gridcell-column-id="${columnName}"][data-gridcell-visible-row-index="${rowIndex}"]`;
+  }
+
   public async getCellElementByColumnName(rowIndex: number, columnName: string) {
     return await this.find.byCssSelector(
-      `[data-test-subj="euiDataGridBody"] [data-test-subj="dataGridRowCell"][data-gridcell-column-id="${columnName}"][data-gridcell-visible-row-index="${rowIndex}"]`
+      this.getCellElementByColumnNameSelector(rowIndex, columnName)
     );
   }
 
@@ -315,6 +319,12 @@ export class DataGridService extends FtrService {
    */
   public async getAllCellElements(rowIndex: number = 0, columnIndex: number = 0) {
     return await this.find.allByCssSelector(this.getCellElementSelector(rowIndex, columnIndex));
+  }
+
+  public async getAllCellElementsByColumnName(rowIndex: number, columnName: string) {
+    return await this.find.allByCssSelector(
+      this.getCellElementByColumnNameSelector(rowIndex, columnName)
+    );
   }
 
   public async getDocCount(): Promise<number> {

--- a/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/discover/search_source_alert.ts
@@ -596,7 +596,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const selectedDataView = await dataViews.getSelectedName();
       expect(selectedDataView).to.be.equal('search-source-*');
 
-      const documentCell = await dataGrid.getCellElement(0, 3);
+      const documentCell = await dataGrid.getCellElementByColumnName(0, '_source');
       const firstRowContent = await documentCell.getVisibleText();
       expect(firstRowContent.includes('runtime-message-fieldmock-message')).to.be.equal(true);
 
@@ -610,7 +610,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const selectedDataView = await dataViews.getSelectedName();
       expect(selectedDataView).to.be.equal('search-source-*');
 
-      const documentCell = await dataGrid.getCellElement(0, 3);
+      const documentCell = await dataGrid.getCellElementByColumnName(0, '_source');
       const firstRowContent = await documentCell.getVisibleText();
       expect(firstRowContent.includes('runtime-message-fieldmock-message')).to.be.equal(true);
     });

--- a/x-pack/test_serverless/functional/test_suites/common/discover/group4/_adhoc_data_views.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/group4/_adhoc_data_views.ts
@@ -189,7 +189,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await addSearchToDashboard('logst*-ss-_bytes-runtimefield');
       await addSearchToDashboard('logst*-ss-_bytes-runtimefield-updated');
 
-      const [firstSearchCell, secondSearchCell] = await dataGrid.getAllCellElements(0, 3);
+      const [firstSearchCell, secondSearchCell] = await dataGrid.getAllCellElementsByColumnName(
+        0,
+        '_bytes-runtimefield'
+      );
       const first = await firstSearchCell.getVisibleText();
       const second = await secondSearchCell.getVisibleText();
 

--- a/x-pack/test_serverless/functional/test_suites/common/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover_ml_uptime/discover/search_source_alert.ts
@@ -617,7 +617,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const selectedDataView = await dataViews.getSelectedName();
       expect(selectedDataView).to.be.equal('search-source-*');
 
-      const documentCell = await dataGrid.getCellElement(0, 3);
+      const documentCell = await dataGrid.getCellElementByColumnName(0, '_source');
       const firstRowContent = await documentCell.getVisibleText();
       expect(firstRowContent.includes('runtime-message-fieldmock-message')).to.be.equal(true);
 
@@ -631,7 +631,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const selectedDataView = await dataViews.getSelectedName();
       expect(selectedDataView).to.be.equal('search-source-*');
 
-      const documentCell = await dataGrid.getCellElement(0, 3);
+      const documentCell = await dataGrid.getCellElementByColumnName(0, '_source');
       const firstRowContent = await documentCell.getVisibleText();
       expect(firstRowContent.includes('runtime-message-fieldmock-message')).to.be.equal(true);
     });


### PR DESCRIPTION
## Summary

This PR fixes the failing Discover functional tests after enabling the security root profile. The issue was that these tests were targeting data grid columns by index, but the column indexes changed due to the row indicators that are now shown by default. They've now been updated to target the columns by name instead of index, which should be reliable across project types.